### PR TITLE
Adding `gulpplugin` keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "main": "index.js",
   "keywords": [
     "gulp",
-    "dotjs"
+    "dotjs",
+    "gulpplugin"
   ],
   "dependencies": {
     "gulp-util": "~2.2.14",


### PR DESCRIPTION
Adding `gulpplugin` keyword so it gets listed in http://gulpjs.com/plugins/
